### PR TITLE
Changing MAF and dataloader to have sigmoid function instead of identity

### DIFF
--- a/src/sygnet/dataloaders.py
+++ b/src/sygnet/dataloaders.py
@@ -110,7 +110,7 @@ def _preprocess_df(df):
     if len(numeric_cols) != 0:
         col_idx_tensor = torch.Tensor([c for c in range(len(numeric_cols))])
         col_idx.append(col_idx_tensor)
-        col_fs.append('identity')
+        col_fs.append('sigmoid')
 
     # Categorical cols idx
     n_numeric = df_num.shape[1]

--- a/src/sygnet/models.py
+++ b/src/sygnet/models.py
@@ -25,14 +25,15 @@ class _MixedActivation(nn.Module):
             logger.error("Cannot construct output layer: unrecognised mixed activation functional")
         self.indices = indices
         self.funcs = funcs
+        self.sigmoid = nn.Sigmoid()
         self.identity = nn.Identity()
         self.device = device
         
     def forward(self, input: Tensor) -> Tensor:
         mixed_out = []
         for number, index_ in enumerate(self.indices):
-            if self.funcs[number] == 'identity':
-                mixed_out.append(self.identity(torch.index_select(input, 1, index_.type(torch.int32).to(self.device))))
+            if self.funcs[number] == 'sigmoid':
+                mixed_out.append(self.sigmoid(torch.index_select(input, 1, index_.type(torch.int32).to(self.device))))
             elif self.funcs[number] == 'softmax':
                 mixed_out.append(nn.functional.gumbel_softmax(torch.index_select(input, 1, index_.type(torch.int32).to(self.device)),tau=0.66, hard=False, dim=1))
             else:


### PR DESCRIPTION
Since we are converting all numeric variables to 0-1 we are better in having sigmoid function instead of identity to facilitate model training 